### PR TITLE
Add keyboard navigation for tabs

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,10 +19,46 @@ const activateTab = (id) => {
     });
 };
 
+const handleTabKeydown = (event) => {
+    const { key } = event;
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(key)) {
+        return;
+    }
+
+    event.preventDefault();
+
+    const currentIndex = tabButtons.indexOf(event.currentTarget);
+    if (currentIndex === -1) {
+        return;
+    }
+
+    let nextIndex = currentIndex;
+
+    if (key === "ArrowLeft") {
+        nextIndex = (currentIndex - 1 + tabButtons.length) % tabButtons.length;
+    } else if (key === "ArrowRight") {
+        nextIndex = (currentIndex + 1) % tabButtons.length;
+    } else if (key === "Home") {
+        nextIndex = 0;
+    } else if (key === "End") {
+        nextIndex = tabButtons.length - 1;
+    }
+
+    const nextTab = tabButtons[nextIndex];
+    if (!nextTab) {
+        return;
+    }
+
+    activateTab(nextTab.dataset.target);
+    nextTab.focus();
+};
+
 tabButtons.forEach((button) => {
     button.addEventListener("click", () => {
         activateTab(button.dataset.target);
     });
+
+    button.addEventListener("keydown", handleTabKeydown);
 });
 
 activateTab("get-started");


### PR DESCRIPTION
## Summary
- add a keydown handler so arrow/home/end keys cycle focus across tabs
- ensure activating a tab via the keyboard keeps aria-selected/tabindex states in sync

## Testing
- ✅ `python playwright navigation check`

------
https://chatgpt.com/codex/tasks/task_e_68cf0c95435c833095c1d02a6fdf50b0