### PR TITLE
Add interactive toolkit and persistent game stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,14 @@
             <h1>Codex Playground</h1>
             <p class="tagline">A clean slate to explore ideas and build fast.</p>
             <a class="cta" href="#get-started">Get Started</a>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false">
+                <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+                <span class="theme-toggle-label">Dark mode</span>
+            </button>
             <nav class="tab-nav" role="tablist" aria-label="Site sections">
                 <button id="tab-overview" class="tab-link" type="button" role="tab" aria-controls="get-started" aria-selected="true" data-target="get-started">Overview</button>
                 <button id="tab-games" class="tab-link" type="button" role="tab" aria-controls="games" aria-selected="false" data-target="games">Games</button>
+                <button id="tab-toolkit" class="tab-link" type="button" role="tab" aria-controls="toolkit" aria-selected="false" data-target="toolkit">Toolkit</button>
             </nav>
         </div>
     </header>
@@ -39,11 +44,62 @@
                         <span class="hud-item"><strong id="score-value">0</strong> pts</span>
                         <span class="hud-item"><strong id="lives-value">3</strong> lives</span>
                         <span class="hud-item"><strong id="wave-value">1</strong> wave</span>
+                        <span class="hud-item">best <strong id="best-score-value">0</strong></span>
+                        <span class="hud-item">top wave <strong id="best-wave-value">1</strong></span>
                     </div>
                     <button id="start-game" type="button" class="start-button">Start Game</button>
                 </div>
 
                 <p id="status-message" class="status" role="status" aria-live="polite">Squadron standing by.</p>
+            </div>
+        </section>
+
+        <section class="section tab-panel" id="toolkit" role="tabpanel" aria-labelledby="tab-toolkit" tabindex="0">
+            <div class="container">
+                <h2>Rapid tinkering toolkit</h2>
+                <p class="section-intro">Keep momentum with a handful of bite-sized helpers. Ideate, focus, and jot notes without leaving the page.</p>
+                <div class="grid toolkit-grid">
+                    <article class="card idea-card" aria-labelledby="idea-card-title">
+                        <h3 id="idea-card-title">Idea spark</h3>
+                        <p>Stir up a direction for your next experiment. Shuffle until something sticks.</p>
+                        <div id="idea-output" class="idea-output" role="status" aria-live="polite">Prototype a micro-dashboard for live launch metrics.</div>
+                        <div class="card-actions">
+                            <button id="new-idea" type="button">Shuffle idea</button>
+                            <button id="copy-idea" type="button">Copy</button>
+                        </div>
+                        <p id="idea-toast" class="idea-toast" role="status" aria-live="polite" hidden></p>
+                    </article>
+
+                    <article class="card timer-card" aria-labelledby="timer-card-title">
+                        <h3 id="timer-card-title">Focus timer</h3>
+                        <p>Pick a sprint, press start, and stay on target. We'll keep count quietly.</p>
+                        <div id="timer-display" class="timer-display" aria-live="polite">25:00</div>
+                        <div class="timer-controls">
+                            <div class="timer-presets" role="group" aria-label="Timer presets">
+                                <button type="button" class="timer-preset" data-timer-preset="15">15 min</button>
+                                <button type="button" class="timer-preset" data-timer-preset="25">25 min</button>
+                                <button type="button" class="timer-preset" data-timer-preset="45">45 min</button>
+                            </div>
+                            <div class="timer-actions">
+                                <button id="timer-toggle" type="button">Start</button>
+                                <button id="timer-reset" type="button">Reset</button>
+                            </div>
+                        </div>
+                        <p id="timer-status" class="timer-status" role="status" aria-live="polite">Ready when you are.</p>
+                    </article>
+
+                    <article class="card notes-card" aria-labelledby="notes-card-title">
+                        <h3 id="notes-card-title">Scratch notes</h3>
+                        <p>Capture tasks or reminders. They'll be waiting the next time you drop in.</p>
+                        <form id="note-form" class="note-form" aria-label="Add a note">
+                            <label class="visually-hidden" for="note-input">Note text</label>
+                            <input id="note-input" type="text" name="note" placeholder="Draft an insight..." autocomplete="off" required>
+                            <button type="submit">Add</button>
+                        </form>
+                        <p id="note-empty" class="note-empty">No notes yet—your canvas is clear.</p>
+                        <ul id="note-list" class="note-list" aria-live="polite"></ul>
+                    </article>
+                </div>
             </div>
         </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,16 @@
     --text: #1f2933;
     --background: #f7f9fc;
     --surface: #ffffff;
+    --muted: rgba(31, 41, 51, 0.6);
+}
+
+body.dark-mode {
+    --accent: #22d3ee;
+    --accent-dark: #0ea5e9;
+    --text: #f8fafc;
+    --background: #0f172a;
+    --surface: #111c30;
+    --muted: rgba(248, 250, 252, 0.65);
 }
 
 * {
@@ -33,6 +43,7 @@ input {
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
     padding: 4rem 0 3rem;
     text-align: center;
+    position: relative;
 }
 
 .site-header h1 {
@@ -40,10 +51,41 @@ input {
     font-size: clamp(2.2rem, 4vw, 3rem);
 }
 
+.theme-toggle {
+    position: absolute;
+    top: 1.5rem;
+    right: clamp(1rem, 5vw, 2rem);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(9, 90, 106, 0.18);
+    background: rgba(12, 123, 147, 0.08);
+    color: var(--accent-dark);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle:focus-visible {
+    outline: 3px solid rgba(12, 123, 147, 0.35);
+    outline-offset: 2px;
+}
+
+.theme-toggle:hover {
+    background: rgba(12, 123, 147, 0.16);
+    transform: translateY(-1px);
+}
+
+.theme-toggle-icon {
+    font-size: 1.1rem;
+}
+
 .tagline {
     margin: 1rem auto 2rem;
     max-width: 500px;
-    color: rgba(31, 41, 51, 0.75);
+    color: var(--muted);
 }
 
 .cta {
@@ -103,6 +145,12 @@ input {
 .section h2,
 .section h3 {
     margin-top: 0;
+}
+
+.section-intro {
+    margin: 0 0 2rem;
+    color: var(--muted);
+    max-width: 580px;
 }
 
 .grid {
@@ -198,5 +246,270 @@ input {
 .site-footer {
     padding: 2rem 0;
     text-align: center;
-    color: rgba(31, 41, 51, 0.6);
+    color: var(--muted);
+}
+
+.card {
+    background: var(--surface);
+    border-radius: 20px;
+    padding: clamp(1.6rem, 3vw, 2.3rem);
+    box-shadow: 0 18px 30px -24px rgba(15, 23, 42, 0.5);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.card p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.card-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.card button,
+.note-form button,
+.timer-actions button,
+.timer-presets button {
+    border: none;
+    border-radius: 12px;
+    padding: 0.65rem 1.4rem;
+    background: var(--accent);
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card button:hover,
+.note-form button:hover,
+.timer-actions button:hover,
+.timer-presets button:hover {
+    background: var(--accent-dark);
+    box-shadow: 0 12px 22px -15px rgba(9, 90, 106, 0.45);
+    transform: translateY(-1px);
+}
+
+.card button:focus-visible,
+.note-form button:focus-visible,
+.timer-actions button:focus-visible,
+.timer-presets button:focus-visible {
+    outline: 3px solid rgba(12, 123, 147, 0.35);
+    outline-offset: 2px;
+}
+
+.card button:disabled,
+.timer-actions button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+}
+
+.toolkit-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.idea-output {
+    min-height: 4.5rem;
+    padding: 1rem;
+    border-radius: 16px;
+    background: rgba(12, 123, 147, 0.08);
+    color: var(--text);
+    font-weight: 600;
+    line-height: 1.5;
+}
+
+.idea-toast {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--accent-dark);
+}
+
+.timer-display {
+    font-size: clamp(2.4rem, 5vw, 3rem);
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-align: center;
+    padding: 1rem;
+    border-radius: 16px;
+    background: rgba(12, 123, 147, 0.08);
+    color: var(--text);
+}
+
+.timer-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.timer-presets {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.timer-presets .timer-preset {
+    background: rgba(12, 123, 147, 0.12);
+    color: var(--accent-dark);
+    box-shadow: none;
+}
+
+.timer-presets .timer-preset:hover {
+    background: rgba(12, 123, 147, 0.2);
+}
+
+.timer-presets .timer-preset.is-active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.timer-status {
+    margin: 0;
+    color: var(--accent-dark);
+    min-height: 1.3rem;
+}
+
+.note-form {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.note-form input {
+    flex: 1;
+    padding: 0.6rem 0.8rem;
+    border-radius: 12px;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    background: rgba(255, 255, 255, 0.75);
+    color: var(--text);
+}
+
+.note-form input:focus-visible {
+    outline: 3px solid rgba(12, 123, 147, 0.35);
+    outline-offset: 2px;
+}
+
+.note-empty {
+    margin: 0;
+    color: var(--muted);
+}
+
+.note-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.note-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 12px;
+    background: rgba(12, 123, 147, 0.08);
+}
+
+.note-label {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    flex: 1;
+    cursor: pointer;
+}
+
+.note-label input[type="checkbox"] {
+    width: 1.05rem;
+    height: 1.05rem;
+    accent-color: var(--accent);
+}
+
+.note-text {
+    flex: 1;
+}
+
+.note-text.is-done {
+    text-decoration: line-through;
+    color: var(--muted);
+}
+
+.note-delete {
+    background: transparent;
+    color: var(--accent-dark);
+    padding: 0.35rem 0.6rem;
+    border-radius: 8px;
+    border: none;
+    font-weight: 600;
+}
+
+.note-delete:hover {
+    background: rgba(12, 123, 147, 0.16);
+}
+
+.note-delete:focus-visible {
+    outline: 3px solid rgba(12, 123, 147, 0.35);
+    outline-offset: 2px;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 600px) {
+    .theme-toggle {
+        position: static;
+        margin: 1rem auto 0;
+    }
+
+    .site-header {
+        padding-top: 3.5rem;
+    }
+
+    .note-form {
+        flex-direction: column;
+    }
+
+    .note-form button {
+        width: 100%;
+    }
+}
+
+body.dark-mode .site-header {
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+body.dark-mode .idea-output,
+body.dark-mode .timer-display {
+    background: rgba(148, 163, 184, 0.14);
+}
+
+body.dark-mode .timer-presets .timer-preset:not(.is-active) {
+    background: rgba(14, 165, 233, 0.22);
+    color: #e0f2fe;
+}
+
+body.dark-mode .note-form input {
+    border-color: rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.65);
+}
+
+body.dark-mode .note-item {
+    background: rgba(148, 163, 184, 0.18);
+}
+
+body.dark-mode .note-delete:hover {
+    background: rgba(148, 163, 184, 0.3);
 }


### PR DESCRIPTION
## Summary
- add a header theme toggle plus a Toolkit tab featuring idea, focus, and note helpers
- implement the supporting JavaScript for dark mode, idea shuffle/copy, a focus timer, and locally stored scratch notes
- extend the Space Invaders HUD with persistent personal best tracking and celebratory messaging

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cf0dc3d4008330831a00989e9ddcfc